### PR TITLE
Phase 01: docker-compose baseline (LightRAG + Langfuse + Ollama bindings)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# CZ-Dev-RAG configuration
+# Copy this file to .env and fill in secrets. Do NOT commit .env.
+
+# --- Ollama (runs natively on the Windows host with direct GPU access) ---
+OLLAMA_HOST=http://host.docker.internal:11434
+
+# --- LightRAG models ---
+LLM_MODEL=qwen2.5:32b-instruct-q4_K_M
+EMBEDDING_MODEL=bge-m3:latest
+EMBEDDING_DIM=1024
+
+# --- LightRAG behavior ---
+LIGHTRAG_PORT=9621
+LIGHTRAG_MODE_DEFAULT=hybrid
+WORKING_DIR=/app/data/rag_storage
+MAX_ASYNC=4
+
+# --- Reranker (wired in phase 03) ---
+RERANK_MODEL=bge-reranker-v2-m3
+RERANK_TOP_K=20
+RERANK_TOP_N=5
+
+# --- Langfuse (tracing — full wiring lands in phase 10) ---
+LANGFUSE_PORT=3000
+LANGFUSE_HOST=http://localhost:3000
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+LANGFUSE_DB_USER=langfuse
+LANGFUSE_DB_PASSWORD=change-me-please
+LANGFUSE_DB_NAME=langfuse
+LANGFUSE_NEXTAUTH_SECRET=change-me-to-a-long-random-string-please
+LANGFUSE_SALT=change-me-to-another-long-random-string-please
+LANGFUSE_INIT_ORG_NAME=CZ Dev
+LANGFUSE_INIT_PROJECT_NAME=cz-dev-rag
+
+# --- MCP server (lands in phase 07) ---
+MCP_SERVER_PORT=9622

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,7 +21,7 @@ _Populated by Phase 4 of the `/idea-to-plan` pipeline. See the Decision Summary 
 - **Branch:** `phase/01-bootstrap-compose`
 - **Depends on:** _none_ (foundational)
 - **Testing Strategy:** Integration smoke — docker compose up + healthcheck loop. No unit tests (pure infra). Source: this phase adds only compose YAML + `.env.example` + `pyproject.toml` stub.
-- **Status:** planned
+- **Status:** shipped, PR open
 
 ### Phase 02 — Demo corpus + README quickstart polish
 - **Issue:** [#3](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/3)

--- a/STATE.md
+++ b/STATE.md
@@ -1,17 +1,17 @@
 # STATE
 
-**Current phase:** 01 — Bootstrap docker-compose baseline
-**Status:** planned (scaffolding complete, awaiting `/gsd:plan-phase 01`)
-**Branch for phase 01:** `phase/01-bootstrap-compose`
+**Current phase:** 02 — Demo corpus + README quickstart polish
+**Status:** phase 01 shipped (PR open, awaiting review)
+**Branch for phase 02:** `phase/02-demo-corpus-quickstart`
 **Last updated:** 2026-04-24
 
 ## Completed phases
 
-_None yet._
+- **Phase 01** — Bootstrap docker-compose baseline — PR open for [#2](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/2) on `phase/01-bootstrap-compose`. `docker compose config` validates.
 
 ## Next up
 
-Phase 01 — see [ROADMAP.md](./ROADMAP.md#phase-01--bootstrap-docker-compose-baseline) and [issue #2](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/2).
+Phase 02 — see [ROADMAP.md](./ROADMAP.md#phase-02--demo-corpus--readme-quickstart-polish) and [issue #3](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/3).
 
 To begin: `/gsd:plan-phase 01` → review plan → `/gsd:execute-phase 01` → `/gsd-review` → `gh pr create ...`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  lightrag:
+    image: ghcr.io/hkuds/lightrag:latest
+    container_name: cz-dev-rag-lightrag
+    restart: unless-stopped
+    ports:
+      - "${LIGHTRAG_PORT:-9621}:9621"
+    environment:
+      HOST: 0.0.0.0
+      PORT: 9621
+      WORKING_DIR: ${WORKING_DIR:-/app/data/rag_storage}
+      INPUT_DIR: /app/data/input
+      LLM_BINDING: ollama
+      LLM_BINDING_HOST: ${OLLAMA_HOST:-http://host.docker.internal:11434}
+      LLM_MODEL: ${LLM_MODEL:-qwen2.5:32b-instruct-q4_K_M}
+      EMBEDDING_BINDING: ollama
+      EMBEDDING_BINDING_HOST: ${OLLAMA_HOST:-http://host.docker.internal:11434}
+      EMBEDDING_MODEL: ${EMBEDDING_MODEL:-bge-m3:latest}
+      EMBEDDING_DIM: ${EMBEDDING_DIM:-1024}
+      MAX_ASYNC: ${MAX_ASYNC:-4}
+      LIGHTRAG_MODE_DEFAULT: ${LIGHTRAG_MODE_DEFAULT:-hybrid}
+    volumes:
+      - ./data/input:/app/data/input
+      - ./data/rag_storage:/app/data/rag_storage
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9621/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+  langfuse-postgres:
+    image: postgres:16-alpine
+    container_name: cz-dev-rag-langfuse-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${LANGFUSE_DB_USER:-langfuse}
+      POSTGRES_PASSWORD: ${LANGFUSE_DB_PASSWORD:-change-me-please}
+      POSTGRES_DB: ${LANGFUSE_DB_NAME:-langfuse}
+    volumes:
+      - langfuse_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  langfuse-web:
+    image: langfuse/langfuse:2
+    container_name: cz-dev-rag-langfuse
+    restart: unless-stopped
+    depends_on:
+      langfuse-postgres:
+        condition: service_healthy
+    ports:
+      - "${LANGFUSE_PORT:-3000}:3000"
+    environment:
+      DATABASE_URL: postgresql://${LANGFUSE_DB_USER:-langfuse}:${LANGFUSE_DB_PASSWORD:-change-me-please}@langfuse-postgres:5432/${LANGFUSE_DB_NAME:-langfuse}
+      NEXTAUTH_URL: ${LANGFUSE_HOST:-http://localhost:3000}
+      NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-change-me-to-a-long-random-string-please}
+      SALT: ${LANGFUSE_SALT:-change-me-to-another-long-random-string-please}
+      TELEMETRY_ENABLED: "false"
+      LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-CZ Dev}
+      LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-cz-dev-rag}
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/api/public/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+volumes:
+  langfuse_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "cz-dev-rag"
+version = "0.1.0"
+description = "Local graph-based RAG knowledge base for CZ Dev agency. LightRAG + RAG-Anything on RTX 3090."
+readme = "README.md"
+license = { text = "MIT" }
+authors = [{ name = "Tamas Czaban" }]
+requires-python = ">=3.11"
+dependencies = []
+
+[dependency-groups]
+dev = [
+    "ruff>=0.6.0",
+    "mypy>=1.11.0",
+    "pytest>=8.0.0",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "UP", "B", "SIM", "RUF"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]


### PR DESCRIPTION
## Summary

Stands up the docker-compose spine that every subsequent phase attaches to.

Closes #2 · References PRD #1 (Slice #1 in the PRD Appendix)

## What changed

- `docker-compose.yml` — three services:
  - `lightrag` (ghcr.io/hkuds/lightrag:latest) on port 9621, reaches Ollama on the Windows host via `host.docker.internal:11434`, mounts `./data/input` + `./data/rag_storage`, `/health` healthcheck
  - `langfuse-postgres` (postgres:16-alpine) with named `langfuse_data` volume, `pg_isready` healthcheck
  - `langfuse-web` (langfuse/langfuse:2) on port 3000, depends on Postgres health, `/api/public/health` healthcheck
- `.env.example` — complete config surface from the PRD (Ollama, LightRAG models + behavior, reranker placeholders, Langfuse, MCP port). Grouped by section with comments.
- `pyproject.toml` — Python 3.11+, uv-compatible, dev deps only (ruff + mypy + pytest). Runtime deps added by later phases as features land.

## Design notes

- **Langfuse v2 pinned intentionally.** v3+ requires ClickHouse + Redis in addition to Postgres — overkill for a two-user KB. Revisit if trace volume ever warrants it. (ADR-005 covers the choice of Langfuse; this is a minor implementation refinement.)
- **`host.docker.internal:host-gateway` extra_host** added for Linux compatibility so non-Windows recruiters can still `docker compose up` (they'd run Ollama natively on Linux instead of WSL).
- **No Ollama container.** Ollama runs natively on the Windows host (ADR-007). Containers reach it via `host.docker.internal`.
- **Later-phase env vars included now** (reranker, MCP, Langfuse keys) so there's only one `.env.example` to maintain.

## How to test locally

```bash
git checkout phase/01-bootstrap-compose
docker compose config          # should print the merged config, no errors
cp .env.example .env
# Optional, requires Ollama + Docker Desktop running:
# ollama pull bge-m3
# ollama pull qwen2.5:32b-instruct-q4_K_M
# docker compose up -d
# curl http://localhost:9621/health    # LightRAG
# curl http://localhost:3000/api/public/health  # Langfuse
```

## Acceptance criteria (from #2)

- [x] `docker compose config` validates — verified locally
- [x] All services defined with healthchecks
- [x] `.env.example` is comprehensive and commented
- [x] LightRAG reaches Ollama via `host.docker.internal:11434` (with `host-gateway` for Linux)
- [ ] Full `docker compose up -d` → all-healthy within 90s — **reviewer-side verification** (not run in CI since it requires Ollama + model pulls)

## Not in this PR (deferred to later phases)

- Reranker service (phase 03)
- MCP server (phase 07)
- Langfuse tracing wiring in LightRAG code (phase 10)
- Demo corpus / README quickstart polish (phase 02)

## Next up

Phase 02 — demo corpus + README quickstart polish ([#3](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/3)). Will be stacked on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
