### PR TITLE
feat(04): ingestion / delete / backup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Exposed tools: `query_kb(question, mode)` and `list_documents()`. Full details i
 - [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) — data flow + component boundaries
 - [`docs/DECISIONS.md`](./docs/DECISIONS.md) — 10 ADRs explaining why-this-not-that
 - [`examples/demo-corpus/README.md`](./examples/demo-corpus/README.md) — what each demo document is for
+- [`scripts/README.md`](./scripts/README.md) — operational scripts: bulk ingest, delete-by-source, restic backup
 
 ## Built with
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ authors = [{ name = "Tamas Czaban" }]
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27.0",
+    "rich>=13.0.0",
+    "typer>=0.12.0",
 ]
 
 [dependency-groups]
@@ -31,4 +33,4 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["src"]
+pythonpath = ["src", "."]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,88 @@
+# CZ-Dev-RAG Operational Scripts
+
+## `ingest.py` — Bulk document ingestion
+
+Posts `.md`, `.txt`, and `.pdf` files from a local folder to the LightRAG HTTP API.
+
+**When to run:** after dropping new client documents into `data/input/<client_slug>/`.
+
+```bash
+# Ingest everything under data/input/acmeco/ (recursive, default)
+python scripts/ingest.py data/input/acmeco/
+
+# Preview without sending anything
+python scripts/ingest.py data/input/acmeco/ --dry-run
+
+# Flat folder only (skip subdirectories)
+python scripts/ingest.py data/input/acmeco/ --no-recursive
+
+# Override LightRAG URL (default: $LIGHTRAG_HOST or http://localhost:9621)
+python scripts/ingest.py data/input/acmeco/ --lightrag-url http://100.x.x.x:9621
+```
+
+Exit code is non-zero if any file fails. All failures are listed in the summary.
+
+---
+
+## `delete_by_source.py` — Delete a document by ID
+
+Calls `DELETE /documents/{doc_id}` on the LightRAG API. LightRAG assigns document IDs
+during ingestion; find them via the LightRAG web UI at `http://localhost:9621`.
+
+**When to run:** when a client relationship ends, a contract is superseded, or a document
+was ingested by mistake.
+
+```bash
+# Interactive confirmation (recommended)
+python scripts/delete_by_source.py <doc_id>
+
+# Skip confirmation (for scripting)
+python scripts/delete_by_source.py <doc_id> --yes
+```
+
+Exit code is non-zero on HTTP error or when the user aborts.
+
+---
+
+## `backup.sh` — Restic backup to Backblaze B2
+
+Backs up the entire `data/` directory (LightRAG graph + vector store + raw input files)
+to a Backblaze B2 bucket using restic. Runs `forget` immediately after with a
+7-daily / 4-weekly retention policy.
+
+**When to run:** daily via Windows Task Scheduler.
+
+**Prerequisites:**
+- `restic` installed and on PATH (`winget install restic` or `choco install restic`)
+- A Backblaze B2 bucket created at [backblaze.com](https://www.backblaze.com)
+- The following environment variables set (add to `.env` or Task Scheduler env):
+
+```
+B2_ACCOUNT_ID=<your-b2-key-id>
+B2_ACCOUNT_KEY=<your-b2-application-key>
+RESTIC_PASSWORD=<strong-passphrase>
+RESTIC_REPOSITORY=b2:<bucket-name>:/cz-dev-rag
+```
+
+**First-time init** (one-off, creates the repo):
+```bash
+restic init
+```
+
+**Manual run:**
+```bash
+source .env  # or set env vars however you prefer
+bash scripts/backup.sh
+```
+
+### Scheduling with Windows Task Scheduler
+
+Run once to register a daily 2 AM task (replace `C:\path\to\CZ-Dev-RAG` with your actual path):
+
+```powershell
+schtasks /Create /SC DAILY /TN "CZ-Dev-RAG Backup" /TR "bash C:\path\to\CZ-Dev-RAG\scripts\backup.sh" /ST 02:00 /RU SYSTEM /F
+```
+
+> Note: Task Scheduler runs as SYSTEM by default; store env vars in the system environment
+> (`System Properties → Advanced → Environment Variables → System variables`) rather than
+> in `.env` so the scheduler task can read them.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env vars: B2_ACCOUNT_ID, B2_ACCOUNT_KEY, RESTIC_PASSWORD, RESTIC_REPOSITORY
+# RESTIC_REPOSITORY should be: b2:bucketname:/path
+
+export B2_ACCOUNT_ID="${B2_ACCOUNT_ID:?B2_ACCOUNT_ID not set}"
+export B2_ACCOUNT_KEY="${B2_ACCOUNT_KEY:?B2_ACCOUNT_KEY not set}"
+export RESTIC_PASSWORD="${RESTIC_PASSWORD:?RESTIC_PASSWORD not set}"
+export RESTIC_REPOSITORY="${RESTIC_REPOSITORY:?RESTIC_REPOSITORY not set}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_DIR="$(dirname "$SCRIPT_DIR")/data"
+
+echo "Starting backup of $DATA_DIR..."
+restic backup "$DATA_DIR" --tag "cz-dev-rag" --verbose
+restic forget --keep-daily 7 --keep-weekly 4 --prune
+echo "Backup complete."

--- a/scripts/delete_by_source.py
+++ b/scripts/delete_by_source.py
@@ -1,0 +1,76 @@
+"""Delete a document from the CZ-Dev-RAG LightRAG knowledge base by document ID."""
+
+from __future__ import annotations
+
+import sys
+from typing import Annotated
+
+import httpx
+import typer
+
+app = typer.Typer(help="Delete a document from the LightRAG knowledge base by document ID.")
+
+DEFAULT_LIGHTRAG_URL = "http://localhost:9621"
+
+
+def delete_document(
+    doc_id: str,
+    *,
+    yes: bool,
+    lightrag_url: str,
+) -> int:
+    """Core delete logic — returns exit code (0 = deleted, 1 = aborted/error)."""
+    if not yes:
+        confirm = typer.prompt(
+            f"Delete document '{doc_id}'? [y/N]",
+            default="N",
+            show_default=False,
+        )
+        if confirm.strip().lower() != "y":
+            typer.echo("Aborted.")
+            return 1
+
+    try:
+        with httpx.Client() as client:
+            response = client.delete(
+                f"{lightrag_url}/documents/{doc_id}",
+                timeout=30.0,
+            )
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        typer.echo(
+            f"Error: HTTP {exc.response.status_code} — {exc.response.text[:200]}",
+            err=True,
+        )
+        return 1
+    except httpx.RequestError as exc:
+        typer.echo(f"Error: Request failed — {exc}", err=True)
+        return 1
+
+    typer.echo(f"Deleted {doc_id}")
+    return 0
+
+
+@app.command()
+def main(
+    doc_id: Annotated[str, typer.Argument(help="Document ID to delete.")],
+    yes: Annotated[
+        bool,
+        typer.Option("--yes/--no-yes", "-y", help="Skip confirmation prompt."),
+    ] = False,
+    lightrag_url: Annotated[
+        str,
+        typer.Option(
+            "--lightrag-url",
+            envvar="LIGHTRAG_HOST",
+            help="LightRAG HTTP API base URL.",
+        ),
+    ] = DEFAULT_LIGHTRAG_URL,
+) -> None:
+    """Delete a document from the LightRAG knowledge base."""
+    exit_code = delete_document(doc_id, yes=yes, lightrag_url=lightrag_url)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,0 +1,178 @@
+"""Bulk ingestion script for CZ-Dev-RAG.
+
+Posts .md, .txt, and .pdf files from a folder to the LightRAG HTTP API.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import httpx
+import typer
+
+try:
+    from rich.console import Console
+    from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
+
+    _RICH = True
+    _console = Console()
+except ImportError:
+    _RICH = False
+    _console = None  # type: ignore[assignment]
+
+app = typer.Typer(help="Ingest documents into the CZ-Dev-RAG LightRAG knowledge base.")
+
+SUPPORTED_EXTENSIONS = {".md", ".txt", ".pdf"}
+DEFAULT_LIGHTRAG_URL = "http://localhost:9621"
+
+
+def _collect_files(folder: Path, *, recursive: bool) -> list[Path]:
+    """Return all supported files under *folder*, ordered by path."""
+    if recursive:
+        files = [
+            p
+            for p in folder.rglob("*")
+            if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+        ]
+    else:
+        files = [
+            p
+            for p in folder.iterdir()
+            if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+        ]
+    return sorted(files)
+
+
+def _post_document(
+    client: httpx.Client,
+    url: str,
+    file_path: Path,
+    folder: Path,
+) -> tuple[bool, str]:
+    """POST a single document to the LightRAG API.
+
+    Returns (success, error_message).
+    """
+    relative = file_path.relative_to(folder)
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return False, f"Cannot read {file_path}: {exc}"
+
+    payload = {
+        "text": text,
+        "metadata": {
+            "source": str(relative).replace("\\", "/"),
+            "filename": file_path.name,
+        },
+    }
+    try:
+        response = client.post(f"{url}/documents/text", json=payload, timeout=120.0)
+        response.raise_for_status()
+        return True, ""
+    except httpx.HTTPStatusError as exc:
+        return False, f"HTTP {exc.response.status_code}: {exc.response.text[:200]}"
+    except httpx.RequestError as exc:
+        return False, f"Request error: {exc}"
+
+
+def ingest_folder(
+    folder: Path,
+    *,
+    recursive: bool,
+    dry_run: bool,
+    lightrag_url: str,
+) -> int:
+    """Core ingestion logic — returns exit code (0 = all ok, 1 = any failure)."""
+    if not folder.is_dir():
+        typer.echo(f"Error: '{folder}' is not a directory.", err=True)
+        return 1
+
+    files = _collect_files(folder, recursive=recursive)
+    if not files:
+        typer.echo("No supported files found (.md, .txt, .pdf).")
+        return 0
+
+    if dry_run:
+        typer.echo(f"Dry run — {len(files)} file(s) would be ingested:")
+        for f in files:
+            typer.echo(f"  {f.relative_to(folder)}")
+        return 0
+
+    succeeded = 0
+    failed = 0
+    errors: list[str] = []
+
+    if _RICH:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+            console=_console,
+        ) as progress:
+            task = progress.add_task("Ingesting", total=len(files))
+            with httpx.Client() as client:
+                for file_path in files:
+                    progress.update(task, description=f"[cyan]{file_path.name}[/cyan]")
+                    ok, err = _post_document(client, lightrag_url, file_path, folder)
+                    if ok:
+                        succeeded += 1
+                    else:
+                        failed += 1
+                        errors.append(f"{file_path.name}: {err}")
+                    progress.advance(task)
+    else:
+        with httpx.Client() as client:
+            for i, file_path in enumerate(files, 1):
+                print(f"[{i}/{len(files)}] {file_path.name} ... ", end="", flush=True)
+                ok, err = _post_document(client, lightrag_url, file_path, folder)
+                if ok:
+                    succeeded += 1
+                    print("OK")
+                else:
+                    failed += 1
+                    errors.append(f"{file_path.name}: {err}")
+                    print(f"FAILED — {err}")
+
+    typer.echo(f"\nSummary: {succeeded} succeeded, {failed} failed.")
+    for err in errors:
+        typer.echo(f"  ERROR: {err}", err=True)
+
+    return 0 if failed == 0 else 1
+
+
+@app.command()
+def main(
+    folder: Annotated[Path, typer.Argument(help="Folder containing documents to ingest.")],
+    recursive: Annotated[
+        bool,
+        typer.Option("--recursive/--no-recursive", help="Recurse into subdirectories."),
+    ] = True,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run/--no-dry-run", help="Print files without ingesting."),
+    ] = False,
+    lightrag_url: Annotated[
+        str,
+        typer.Option(
+            "--lightrag-url",
+            envvar="LIGHTRAG_HOST",
+            help="LightRAG HTTP API base URL.",
+        ),
+    ] = DEFAULT_LIGHTRAG_URL,
+) -> None:
+    """Ingest a folder of documents into the LightRAG knowledge base."""
+    exit_code = ingest_folder(
+        folder,
+        recursive=recursive,
+        dry_run=dry_run,
+        lightrag_url=lightrag_url,
+    )
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,0 +1,155 @@
+"""Unit tests for scripts/delete_by_source.py — no real HTTP calls."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.delete_by_source import delete_document
+
+# ---------------------------------------------------------------------------
+# --yes flag skips confirmation
+# ---------------------------------------------------------------------------
+
+
+def test_yes_flag_sends_delete_without_prompt() -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+
+    with patch("scripts.delete_by_source.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.delete.return_value = mock_response
+
+        exit_code = delete_document(
+            "doc-abc-123",
+            yes=True,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 0
+    mock_instance.delete.assert_called_once_with(
+        "http://localhost:9621/documents/doc-abc-123",
+        timeout=30.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt — user says 'y'
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_yes_sends_delete() -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+
+    with (
+        patch("scripts.delete_by_source.httpx.Client") as mock_client_cls,
+        patch("scripts.delete_by_source.typer.prompt", return_value="y"),
+    ):
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.delete.return_value = mock_response
+
+        exit_code = delete_document(
+            "doc-abc-123",
+            yes=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 0
+    mock_instance.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Confirmation prompt — user says 'n'
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_no_aborts_without_delete() -> None:
+    with (
+        patch("scripts.delete_by_source.httpx.Client") as mock_client_cls,
+        patch("scripts.delete_by_source.typer.prompt", return_value="n"),
+    ):
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        exit_code = delete_document(
+            "doc-abc-123",
+            yes=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 1
+    mock_instance.delete.assert_not_called()
+
+
+def test_prompt_empty_aborts_without_delete() -> None:
+    with (
+        patch("scripts.delete_by_source.httpx.Client") as mock_client_cls,
+        patch("scripts.delete_by_source.typer.prompt", return_value=""),
+    ):
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        exit_code = delete_document(
+            "doc-abc-123",
+            yes=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 1
+    mock_instance.delete.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+def test_http_error_returns_nonzero() -> None:
+    import httpx as _httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_response.text = "Not Found"
+    http_error = _httpx.HTTPStatusError(
+        "404",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch("scripts.delete_by_source.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.delete.side_effect = http_error
+
+        exit_code = delete_document(
+            "doc-missing",
+            yes=True,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 1
+
+
+def test_request_error_returns_nonzero() -> None:
+    import httpx as _httpx
+
+    with patch("scripts.delete_by_source.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.delete.side_effect = _httpx.ConnectError("Connection refused")
+
+        exit_code = delete_document(
+            "doc-abc-123",
+            yes=True,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,191 @@
+"""Unit tests for scripts/ingest.py — no real HTTP calls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scripts.ingest import _collect_files, ingest_folder
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_docs(tmp_path: Path) -> tuple[Path, Path]:
+    """Create two synthetic markdown files and return their paths."""
+    doc_a = tmp_path / "doc_a.md"
+    doc_b = tmp_path / "doc_b.md"
+    doc_a.write_text("# Doc A\n\nContent of document A.", encoding="utf-8")
+    doc_b.write_text("# Doc B\n\nContent of document B.", encoding="utf-8")
+    return doc_a, doc_b
+
+
+# ---------------------------------------------------------------------------
+# _collect_files
+# ---------------------------------------------------------------------------
+
+
+def test_collect_files_non_recursive(tmp_path: Path) -> None:
+    doc_a, doc_b = _make_docs(tmp_path)
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "doc_c.md").write_text("C", encoding="utf-8")
+
+    files = _collect_files(tmp_path, recursive=False)
+    assert set(files) == {doc_a, doc_b}
+
+
+def test_collect_files_recursive(tmp_path: Path) -> None:
+    doc_a, doc_b = _make_docs(tmp_path)
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    doc_c = subdir / "doc_c.md"
+    doc_c.write_text("C", encoding="utf-8")
+
+    files = _collect_files(tmp_path, recursive=True)
+    assert set(files) == {doc_a, doc_b, doc_c}
+
+
+def test_collect_files_filters_extensions(tmp_path: Path) -> None:
+    (tmp_path / "keep.md").write_text("keep", encoding="utf-8")
+    (tmp_path / "keep.txt").write_text("keep", encoding="utf-8")
+    (tmp_path / "skip.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "skip.py").write_text("", encoding="utf-8")
+
+    files = _collect_files(tmp_path, recursive=False)
+    names = {f.name for f in files}
+    assert names == {"keep.md", "keep.txt"}
+
+
+# ---------------------------------------------------------------------------
+# ingest_folder — dry run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_makes_no_http_calls(tmp_path: Path) -> None:
+    _make_docs(tmp_path)
+
+    with patch("scripts.ingest.httpx.Client") as mock_client_cls:
+        exit_code = ingest_folder(
+            tmp_path,
+            recursive=True,
+            dry_run=True,
+            lightrag_url="http://localhost:9621",
+        )
+
+    mock_client_cls.assert_not_called()
+    assert exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# ingest_folder — real run (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_posts_each_file(tmp_path: Path) -> None:
+    _make_docs(tmp_path)
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+
+    with patch("scripts.ingest.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.post.return_value = mock_response
+
+        exit_code = ingest_folder(
+            tmp_path,
+            recursive=True,
+            dry_run=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 0
+    assert mock_instance.post.call_count == 2
+
+
+def test_ingest_posts_correct_url_and_body(tmp_path: Path) -> None:
+    single_dir = tmp_path / "single"
+    single_dir.mkdir()
+    test_file = single_dir / "test.md"
+    test_file.write_text("Hello world", encoding="utf-8")
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+
+    with patch("scripts.ingest.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.post.return_value = mock_response
+
+        exit_code = ingest_folder(
+            single_dir,
+            recursive=False,
+            dry_run=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 0
+    assert mock_instance.post.call_count == 1
+
+    call_args = mock_instance.post.call_args
+    assert call_args[0][0] == "http://localhost:9621/documents/text"
+
+    payload = call_args[1]["json"]
+    assert payload["text"] == "Hello world"
+    assert payload["metadata"]["source"] == "test.md"
+    assert payload["metadata"]["filename"] == "test.md"
+
+
+def test_ingest_returns_nonzero_on_failure(tmp_path: Path) -> None:
+    _make_docs(tmp_path)
+
+    import httpx as _httpx
+
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_response.text = "Internal Server Error"
+    http_error = _httpx.HTTPStatusError(
+        "500",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    with patch("scripts.ingest.httpx.Client") as mock_client_cls:
+        mock_instance = MagicMock()
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=mock_instance)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        mock_instance.post.side_effect = http_error
+
+        exit_code = ingest_folder(
+            tmp_path,
+            recursive=True,
+            dry_run=False,
+            lightrag_url="http://localhost:9621",
+        )
+
+    assert exit_code == 1
+
+
+def test_ingest_empty_folder_returns_zero(tmp_path: Path) -> None:
+    exit_code = ingest_folder(
+        tmp_path,
+        recursive=True,
+        dry_run=False,
+        lightrag_url="http://localhost:9621",
+    )
+    assert exit_code == 0
+
+
+def test_ingest_nonexistent_folder_returns_nonzero(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist"
+    exit_code = ingest_folder(
+        missing,
+        recursive=True,
+        dry_run=False,
+        lightrag_url="http://localhost:9621",
+    )
+    assert exit_code == 1

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -29,6 +38,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -43,6 +64,8 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "rich" },
+    { name = "typer" },
 ]
 
 [package.dev-dependencies]
@@ -53,7 +76,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", specifier = ">=0.27.0" }]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "typer", specifier = ">=0.12.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -191,6 +218,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +350,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -324,6 +385,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
     { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
     { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **`scripts/ingest.py`** — typer CLI that bulk-POSTs `.md`, `.txt`, `.pdf` files to `POST /documents/text`. Supports `--recursive/--no-recursive`, `--dry-run`, `--lightrag-url` (env: `LIGHTRAG_HOST`). Rich progress bar when rich is installed; plain stdout fallback. Exits nonzero if any file fails.
- **`scripts/delete_by_source.py`** — typer CLI that calls `DELETE /documents/{doc_id}`. Requires `--yes` or interactive `[y/N]` confirmation. Exits nonzero on HTTP error or abort.
- **`scripts/backup.sh`** — bash script: restic backup of `data/` to Backblaze B2 with 7-daily/4-weekly retention and `--prune`.
- **`scripts/README.md`** — usage guide + Windows Task Scheduler one-liner for daily backup scheduling.
- **`tests/test_ingest.py` + `tests/test_delete.py`** — 15 unit tests; all HTTP calls mocked via `unittest.mock.patch`. No real LightRAG calls in CI.
- **`pyproject.toml`** — adds `typer>=0.12.0`, `rich>=13.0.0`, `httpx>=0.27.0` to runtime deps.

Closes #5

## Test plan

- [x] `uv run ruff check scripts/ tests/` — all checks pass
- [x] `uv run mypy scripts/ tests/ --ignore-missing-imports` — no issues
- [x] `uv run pytest tests/ -v` — 15/15 passed
- [ ] Manual smoke: `python scripts/ingest.py examples/demo-corpus/ --dry-run` (no live stack needed)
- [ ] Manual smoke: `python scripts/ingest.py examples/demo-corpus/` against a running stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)