### PR TITLE
Phase 12: File Tailscale SSH follow-up issue + update ADR-008 rollout status

### DIFF
--- a/.planning/phases/12-tailscale-ssh-issue-adr008/EXEC-LOG.md
+++ b/.planning/phases/12-tailscale-ssh-issue-adr008/EXEC-LOG.md
@@ -1,0 +1,31 @@
+# Phase 12 — Execution Log
+
+**Date:** 2026-04-30
+**Branch:** `phase/12-tailscale-ssh-issue-adr008`
+**Executor:** Claude Sonnet (gsd-run-phase inline)
+
+## Steps executed
+
+1. Created GitHub issue #35 "Enable Tailscale SSH for Tamas-only convenience access"
+   - Includes use case, deferred-from-v1 rationale, acceptance criteria, and notes
+   - URL: https://github.com/TamasCzaban/CZ-Dev-RAG/issues/35
+
+2. Appended "Rollout status (2026-04-30)" to ADR-008 in `docs/DECISIONS.md`
+   - Records Tailscale v1 rollout completion date
+   - References issue #35 for the Tailscale SSH follow-up
+
+## Files changed
+
+- `docs/DECISIONS.md` — +2 lines (rollout status note in ADR-008)
+- `.planning/phases/12-tailscale-ssh-issue-adr008/PLAN.md` — new
+- `.planning/phases/12-tailscale-ssh-issue-adr008/EXEC-LOG.md` — new
+
+## Tests
+
+None required (docs-only phase).
+
+## Acceptance criteria check
+
+- [x] GH issue #35 "Enable Tailscale SSH for Tamas-only convenience access" created
+- [x] `docs/DECISIONS.md` ADR-008 has rollout status note with date + issue reference
+- [x] No Tailscale SSH config added

--- a/.planning/phases/12-tailscale-ssh-issue-adr008/PLAN.md
+++ b/.planning/phases/12-tailscale-ssh-issue-adr008/PLAN.md
@@ -1,0 +1,27 @@
+# Phase 12 — File Tailscale SSH follow-up issue + update ADR-008 rollout status
+
+**Issue:** [#28](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/28)
+**Branch:** `phase/12-tailscale-ssh-issue-adr008`
+**Type:** docs-only + GH issue creation — no code, no tests
+
+## Objective
+
+Close the deferred Tailscale SSH item from the Decision Summary by:
+1. Creating a GitHub issue for "Enable Tailscale SSH for Tamas-only convenience access"
+2. Appending a "Rollout status" note to ADR-008 in `docs/DECISIONS.md` with the completion date and a forward reference to the new issue
+
+## Steps
+
+1. Create GitHub issue: "Enable Tailscale SSH for Tamas-only convenience access"
+   - Body: use case (access host from own laptop when box is on), note that it is deferred from the Tailscale v1 rollout
+   - Label: `slice` or `enhancement`
+
+2. Append to ADR-008 in `docs/DECISIONS.md`:
+   - A "Rollout status" subsection with today's date (2026-04-30)
+   - Forward reference to the new GitHub issue number
+
+## Acceptance criteria (from issue #28)
+
+- [ ] New GH issue "Enable Tailscale SSH for Tamas-only convenience access" exists with use-case description and deferred-from-v1 note
+- [ ] `docs/DECISIONS.md` ADR-008 has appended "Rollout status" note with date + issue reference
+- [ ] No Tailscale SSH config added

--- a/.planning/phases/12-tailscale-ssh-issue-adr008/REVIEW.md
+++ b/.planning/phases/12-tailscale-ssh-issue-adr008/REVIEW.md
@@ -1,0 +1,26 @@
+# Phase 12 — Review
+
+**Date:** 2026-04-30
+**Reviewer:** Claude Sonnet (gsd-run-phase inline reviewer)
+**Branch:** `phase/12-tailscale-ssh-issue-adr008`
+**Verdict:** APPROVE
+
+## Acceptance criteria check
+
+- [x] GH issue #35 "Enable Tailscale SSH for Tamas-only convenience access" exists
+  - Includes use case (access host from laptop), deferred-from-v1 rationale, and acceptance criteria for the future SSH implementation
+- [x] `docs/DECISIONS.md` ADR-008 has rollout status note appended (2026-04-30) with reference to #35
+- [x] No Tailscale SSH config added to repo — confirmed by diff (docs-only changes)
+
+## Findings
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| Should fix | 0 |
+| Nit | 0 |
+| Question | 0 |
+
+## Summary
+
+Clean docs-only phase. The 2-line ADR-008 addition is well-formed and follows the ADR format. The GH issue body is thorough: use case, deferred rationale, AC for future implementation, and back-link to DECISIONS.md. No code was changed. No risk.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -100,6 +100,8 @@ Format: `ADR-NNN` · short title · date · status.
 
 **Consequences:** If Tamas's Tailscale auth key leaks, the KB is exposed to that device — document key rotation in the runbook. A future client-facing SaaS version would need real auth; explicitly out of v1 scope.
 
+**Rollout status (2026-04-30):** Tailscale v1 rollout completed (Phases 13–17). Both Tamas and Zsombor can reach LightRAG + MCP over the tailnet. Tailscale SSH (Tamas-only convenience access) was intentionally deferred — tracked in [#35](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/35).
+
 ---
 
 ## ADR-009 · MCP server wrapper as a first-class component · 2026-04-24 · accepted


### PR DESCRIPTION
## Summary

- Appends a **Rollout status (2026-04-30)** note to ADR-008 in `docs/DECISIONS.md`, recording that the Tailscale v1 rollout is complete and linking the Tailscale SSH follow-up issue
- Creates GitHub issue [#35](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/35) — "Enable Tailscale SSH for Tamas-only convenience access" — as the deferred tracker from the Decision Summary

## Changes

- `docs/DECISIONS.md` — +2 lines in ADR-008 (rollout status note)
- `.planning/phases/12-tailscale-ssh-issue-adr008/` — PLAN.md, EXEC-LOG.md, REVIEW.md (phase artifacts)

## Test plan

- [x] Docs-only slice — no code changes, no tests required
- [x] GH issue #35 exists with use case, deferred rationale, and AC for future implementation
- [x] ADR-008 rollout status note is present in `docs/DECISIONS.md` with date and issue reference
- [x] No Tailscale SSH config added to repo

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)