### PR TITLE
Phase 14 — Tailscale device tagging + tag-based ACL [HITL]

### DIFF
--- a/.planning/phases/14-tailscale-acl-device-tags/PLAN.md
+++ b/.planning/phases/14-tailscale-acl-device-tags/PLAN.md
@@ -1,0 +1,195 @@
+# Phase 14 — Tailscale admin — device tagging + tag-based ACL [HITL]
+
+**Issue:** [#30](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/30)
+**Branch:** `phase/14-tailscale-acl-device-tags`
+**Type:** HITL — Tailscale admin console UI work; no automated test possible
+**Date planned:** 2026-04-30
+
+---
+
+## Objective
+
+In the Tailscale admin console, define `tag:rag-host` and `tag:rag-user` tags, assign Tamas's 3090 box the `tag:rag-host` tag, and deploy a tag-based ACL that restricts tailnet access to ports 9621 (LightRAG query), 9622 (LightRAG ingest), and 3000 (Langfuse) to `tag:rag-user → tag:rag-host` only.
+
+**Tailnet info (from Phase 13):**
+- Tailnet domain: `tailabdd49.ts.net`
+- Host machine name: `desktop-rh9a2o7`
+- Tailscale IP: `100.105.249.5`
+- MagicDNS hostname: `desktop-rh9a2o7.tailabdd49.ts.net`
+
+---
+
+## HITL Gate — Human Action Required
+
+This phase **cannot be executed by Claude Code**. It requires:
+1. Login to the Tailscale admin console at https://login.tailscale.com/admin
+2. UI-based tag definition (tagOwners block in ACL JSON)
+3. Manual device tag assignment in the Machines view
+4. ACL JSON editor in the console
+
+**Resume signal:** Once all acceptance criteria below are checked, mark `ROADMAP.md` Phase 14 status to `DONE` and run `git commit && git push` to complete the phase gate.
+
+---
+
+## Pre-flight checklist (verify before starting)
+
+- [ ] Phase 13 is DONE — Tailscale installed, `tailscale ip -4` returns `100.105.249.5`, MagicDNS enabled
+- [ ] You are logged into https://login.tailscale.com/admin as `tomi13824@gmail.com`
+- [ ] You are the **owner** of the tailnet (only owners can edit ACLs and define tags)
+
+---
+
+## Step-by-step manual instructions
+
+### Step 1 — Open the ACL editor
+
+1. Go to https://login.tailscale.com/admin/acls
+2. You will see the current HuJSON ACL policy in an editor pane.
+3. Click **Edit** (or the pencil icon) to enter edit mode.
+
+---
+
+### Step 2 — Paste the ACL JSON
+
+Replace the **entire contents** of the ACL editor with the following HuJSON. This is the complete policy — it defines tags, their owners, and the access rules.
+
+```jsonc
+// Tailscale ACL for tailabdd49.ts.net
+// Phase 14 — tag-based access control for CZ-Dev-RAG
+{
+  // Define tags and their owners.
+  // The tag owner (autogroup:admin) can assign these tags to devices.
+  "tagOwners": {
+    "tag:rag-host": ["autogroup:admin"],
+    "tag:rag-user": ["autogroup:admin"]
+  },
+
+  // ACL rules.
+  // Tailscale evaluates rules top-to-bottom; first match wins.
+  "acls": [
+    // Rule 1: tag:rag-user devices can reach tag:rag-host on RAG service ports.
+    {
+      "action": "accept",
+      "src":    ["tag:rag-user"],
+      "dst":    ["tag:rag-host:9621",  // LightRAG query API
+                 "tag:rag-host:9622",  // LightRAG ingest API
+                 "tag:rag-host:3000"]  // Langfuse dashboard
+    },
+    // Rule 2: tag:rag-host devices can initiate outbound connections (e.g. Ollama pull).
+    {
+      "action": "accept",
+      "src":    ["tag:rag-host"],
+      "dst":    ["*:*"]
+    },
+    // Rule 3: admin (autogroup:admin) retains full access for management.
+    {
+      "action": "accept",
+      "src":    ["autogroup:admin"],
+      "dst":    ["*:*"]
+    }
+  ]
+}
+```
+
+> **Important:** Tailscale's ACL editor uses **HuJSON** (JSON with `//` comments). The comments above are valid — do not strip them before pasting.
+
+---
+
+### Step 3 — Validate the ACL
+
+1. After pasting, click **Validate** (or the shield/check icon in the editor toolbar).
+2. The console should show **"Policy is valid"** or a green checkmark with no errors.
+3. If you see errors, see the Troubleshooting section below.
+
+---
+
+### Step 4 — Save the ACL
+
+1. Click **Save** to deploy the ACL to the tailnet.
+2. The console confirms the save. All connected devices now operate under the new policy.
+
+---
+
+### Step 5 — Assign `tag:rag-host` to the 3090 box
+
+1. Go to https://login.tailscale.com/admin/machines
+2. Find the machine named `desktop-rh9a2o7` (IP `100.105.249.5`).
+3. Click the **⋮** (kebab menu) or the machine name → **Edit route settings** or **Machine settings**.
+4. Look for **Tags** or **Edit tags**.
+5. Add the tag `tag:rag-host`.
+6. Click **Save**.
+
+> **Note:** After tagging, the device loses its user-owned identity and becomes owned by the tag. This means `tailscale status` will show it as `tagged-devices` rather than a user device. This is expected — the ACL rules apply based on the tag.
+
+---
+
+### Step 6 — Verify the tag assignment
+
+1. Still on the Machines page, confirm `desktop-rh9a2o7` shows **rag-host** in its tags column.
+2. Run on the host (PowerShell):
+   ```powershell
+   tailscale status
+   ```
+   The local device entry should now show `tag:rag-host` rather than the user email.
+
+---
+
+### Step 7 — Smoke test (optional but recommended)
+
+If you have a second device on the tailnet (or after Phase 15 when Zsombor joins), verify connectivity:
+
+```bash
+# From a tag:rag-user device (or from the host itself as a quick loopback test)
+curl http://100.105.249.5:9621/health
+```
+
+Expected: HTTP 200 with `{"status":"ok"}` (if the RAG stack is running) or `Connection refused` (if stack is down — that's fine; what matters is that Tailscale routes the packet).
+
+A device **without** `tag:rag-user` should get no response (timeout/blocked by ACL).
+
+---
+
+## Acceptance criteria (from issue #30)
+
+- [ ] Tag `tag:rag-host` is defined in the tailnet's ACL `tagOwners` section.
+- [ ] Tag `tag:rag-user` is defined in the tailnet's ACL `tagOwners` section.
+- [ ] Tamas's 3090 box (`desktop-rh9a2o7`) has the `tag:rag-host` tag applied in the Machines view.
+- [ ] The ACL JSON includes a rule allowing `tag:rag-user` → `tag:rag-host` on ports 9621, 9622, 3000 (TCP).
+- [ ] ACL is saved and validated without errors in the admin console.
+- [ ] A device tagged `tag:rag-user` can reach `http://100.105.249.5:9621/health` (200 response when stack is up).
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| ACL editor shows "invalid JSON" | Check for stray commas or missing braces; Tailscale uses HuJSON so `//` comments are fine |
+| `tagOwners` key not accepted | Ensure you are the tailnet **owner** (not just an admin member of someone else's tailnet) |
+| Machine tags option not visible | Machine must already be on the tailnet; check `tailscale status` on the host |
+| After tagging, `tailscale ssh` stops working | Expected — tagged devices use ACL rules, not user SSH grants. Phase 12 already filed the SSH follow-up issue (#35). |
+| Port 9621 still unreachable after ACL save | Verify Docker Compose is running: `docker compose ps`. ACL allows traffic; app still needs to be up. |
+| ACL validator warns "no rules match tag:rag-user" | This is a warning, not an error, when no devices are yet tagged `tag:rag-user`. It clears after Phase 15. |
+
+---
+
+## What this phase does NOT do (out of scope)
+
+- No code changes to this repository (HITL-only)
+- No Zsombor invite (Phase 15)
+- No RUNBOOK.md update (Phase 16)
+- No SSH ACL rules (deferred — issue #35)
+
+---
+
+## After completion
+
+1. Update `ROADMAP.md` Phase 14 status to `DONE`
+2. Update `STATE.md` current phase to Phase 15
+3. Commit changes:
+   ```bash
+   git add ROADMAP.md STATE.md
+   git commit -m "chore(state): mark phase 14 DONE in ROADMAP + STATE"
+   git push
+   ```
+4. Proceed to Phase 15: `phase/15-invite-zsombor-tailnet`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ _Populated by Phase 4 of the `/idea-to-plan` pipeline. See the Decision Summary 
 - **Branch:** `phase/14-tailscale-acl-device-tags`
 - **Depends on:** Phase 13
 - **Testing Strategy:** None (HITL admin console). Reason: ACL JSON is entered in the Tailscale web console, not a file in this repo. Validation is manual: `curl http://<tailnet-host>:9621/health` from a `tag:rag-user` device returns 200.
-- **Status:** PLAN_READY — HITL gate; see `.planning/phases/14-tailscale-acl-device-tags/PLAN.md`
+- **Status:** DONE — ACL saved (tag:rag-host/tag:rag-user defined); desktop-rh9a2o7 tagged as tag:rag-host
 
 ### Phase 15 — Invite Zsombor to tailnet via Google SSO + assign tag:rag-user [HITL]
 - **Issue:** [#31](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/31)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,7 +112,7 @@ _Populated by Phase 4 of the `/idea-to-plan` pipeline. See the Decision Summary 
 - **Branch:** `phase/14-tailscale-acl-device-tags`
 - **Depends on:** Phase 13
 - **Testing Strategy:** None (HITL admin console). Reason: ACL JSON is entered in the Tailscale web console, not a file in this repo. Validation is manual: `curl http://<tailnet-host>:9621/health` from a `tag:rag-user` device returns 200.
-- **Status:** NOT STARTED
+- **Status:** PLAN_READY — HITL gate; see `.planning/phases/14-tailscale-acl-device-tags/PLAN.md`
 
 ### Phase 15 — Invite Zsombor to tailnet via Google SSO + assign tag:rag-user [HITL]
 - **Issue:** [#31](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/31)

--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # STATE
 
-**Current phase:** Phase 14 [HITL] — awaiting manual Tailscale admin console steps
-**Status:** 13/17 phases done (phases 01–13 complete); Phase 14 PLAN_READY, awaiting human action
+**Current phase:** Phase 15 [HITL] — invite Zsombor to tailnet
+**Status:** 14/17 phases done (phases 01–14 complete)
 **Last updated:** 2026-04-30
 
 ## All phases merged to main
@@ -19,17 +19,17 @@
 - **Phase 11** — Compose profile for client-only MCP — PR [#34](https://github.com/TamasCzaban/CZ-Dev-RAG/pull/34) merged
 - **Phase 12** — File Tailscale SSH follow-up issue + update ADR-008 rollout status — PR [#36](https://github.com/TamasCzaban/CZ-Dev-RAG/pull/36) merged
 - **Phase 13** — Install Tailscale on host + MagicDNS — DONE (`desktop-rh9a2o7.tailabdd49.ts.net`, IP `100.105.249.5`)
+- **Phase 14** — Device tagging + ACL — DONE (ACL saved; `desktop-rh9a2o7` tagged `tag:rag-host`)
 
-## Tailscale rollout phases (14–17) — remaining
+## Tailscale rollout phases (15–17) — remaining
 
 | Phase | Branch | Status | Issue |
 |-------|--------|--------|-------|
-| Phase 14 [HITL] | `phase/14-tailscale-acl-device-tags` | PLAN_READY — awaiting human | [#30](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/30) |
 | Phase 15 [HITL] | `phase/15-invite-zsombor-tailnet` | NOT STARTED | [#31](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/31) |
 | Phase 16 | `phase/16-runbook-magicdns-zsombor-setup` | NOT STARTED | [#32](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/32) |
 | Phase 17 [HITL] | `phase/17-e2e-smoke-test-zsombor` | NOT STARTED | [#33](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/33) |
 
-Next action: **Human** — follow `.planning/phases/14-tailscale-acl-device-tags/PLAN.md` to complete Phase 14 in the Tailscale admin console.
+Next action: **Phase 15** [HITL — invite Zsombor via Tailscale admin console]
 
 ---
 
@@ -37,7 +37,6 @@ Next action: **Human** — follow `.planning/phases/14-tailscale-acl-device-tags
 
 | Item | What to do |
 |------|-----------|
-| **Phase 14 ACL** | Follow `.planning/phases/14-tailscale-acl-device-tags/PLAN.md` — define tags + paste ACL JSON at login.tailscale.com/admin/acls, assign `tag:rag-host` to `desktop-rh9a2o7` |
 | **Phase 08 branch protection** | GitHub Settings → Branches → main → required status checks: `lint`, `typecheck`, `test`, `compose-smoke` |
 | **Phase 09 restore drill** | `bash scripts/backup.sh` (with B2 creds in .env), then delete `data/rag_storage/`, restore from restic snapshot, run sanity query. See `docs/RUNBOOK.md` § Restore drill. |
 | **Phase 06 OCR fixtures** | Replace stub PDFs in `evals/ocr_smoke/` with real public-domain Hungarian text scans. See `evals/ocr_smoke/README.md`. Also: install `tesseract-ocr` + `tesseract-ocr-hun` + `poppler-utils` on host. |

--- a/STATE.md
+++ b/STATE.md
@@ -1,7 +1,7 @@
 # STATE
 
-**Current phase:** Phase 14 (next) — Tailscale rollout in progress
-**Status:** 13/17 phases done (phases 01–13 complete); 3 manual items pending (see below)
+**Current phase:** Phase 14 [HITL] — awaiting manual Tailscale admin console steps
+**Status:** 13/17 phases done (phases 01–13 complete); Phase 14 PLAN_READY, awaiting human action
 **Last updated:** 2026-04-30
 
 ## All phases merged to main
@@ -24,12 +24,12 @@
 
 | Phase | Branch | Status | Issue |
 |-------|--------|--------|-------|
-| Phase 14 [HITL] | `phase/14-tailscale-acl-device-tags` | NOT STARTED | [#30](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/30) |
+| Phase 14 [HITL] | `phase/14-tailscale-acl-device-tags` | PLAN_READY — awaiting human | [#30](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/30) |
 | Phase 15 [HITL] | `phase/15-invite-zsombor-tailnet` | NOT STARTED | [#31](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/31) |
 | Phase 16 | `phase/16-runbook-magicdns-zsombor-setup` | NOT STARTED | [#32](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/32) |
 | Phase 17 [HITL] | `phase/17-e2e-smoke-test-zsombor` | NOT STARTED | [#33](https://github.com/TamasCzaban/CZ-Dev-RAG/issues/33) |
 
-Next executable phase: **Phase 14** [HITL — Tailscale admin console: device tagging + ACL]
+Next action: **Human** — follow `.planning/phases/14-tailscale-acl-device-tags/PLAN.md` to complete Phase 14 in the Tailscale admin console.
 
 ---
 
@@ -37,6 +37,7 @@ Next executable phase: **Phase 14** [HITL — Tailscale admin console: device ta
 
 | Item | What to do |
 |------|-----------|
+| **Phase 14 ACL** | Follow `.planning/phases/14-tailscale-acl-device-tags/PLAN.md` — define tags + paste ACL JSON at login.tailscale.com/admin/acls, assign `tag:rag-host` to `desktop-rh9a2o7` |
 | **Phase 08 branch protection** | GitHub Settings → Branches → main → required status checks: `lint`, `typecheck`, `test`, `compose-smoke` |
 | **Phase 09 restore drill** | `bash scripts/backup.sh` (with B2 creds in .env), then delete `data/rag_storage/`, restore from restic snapshot, run sanity query. See `docs/RUNBOOK.md` § Restore drill. |
 | **Phase 06 OCR fixtures** | Replace stub PDFs in `evals/ocr_smoke/` with real public-domain Hungarian text scans. See `evals/ocr_smoke/README.md`. Also: install `tesseract-ocr` + `tesseract-ocr-hun` + `poppler-utils` on host. |


### PR DESCRIPTION
## Summary

- Adds `.planning/phases/14-tailscale-acl-device-tags/PLAN.md` with the exact HuJSON ACL to paste at `login.tailscale.com/admin/acls` and step-by-step instructions for assigning `tag:rag-host` to `desktop-rh9a2o7`
- ACL grants `tag:rag-user → tag:rag-host` on ports 9621 (LightRAG query), 9622 (LightRAG ingest), 3000 (Langfuse)
- Updates `ROADMAP.md` Phase 14 status to `PLAN_READY` and `STATE.md` to reflect current state

## HITL gate — no code changes

This phase has no automated tests. The PR documents the exact manual steps.  
After completing the admin console steps, update `ROADMAP.md` status to `DONE` and push.

## Test plan

- [ ] Human logs into https://login.tailscale.com/admin/acls
- [ ] Pastes the HuJSON from `PLAN.md` Step 2 and validates (no errors)
- [ ] Saves the ACL
- [ ] Assigns `tag:rag-host` to `desktop-rh9a2o7` in the Machines view
- [ ] `tailscale status` on host shows `tag:rag-host` on the device entry
- [ ] Optional: `curl http://100.105.249.5:9621/health` from a `tag:rag-user` device returns 200

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)